### PR TITLE
Bug fix/sp2-3 state

### DIFF
--- a/addons/binding/org.openhab.binding.broadlink/src/main/java/org/openhab/binding/broadlink/handler/BroadlinkSocketModel2Handler.java
+++ b/addons/binding/org.openhab.binding.broadlink/src/main/java/org/openhab/binding/broadlink/handler/BroadlinkSocketModel2Handler.java
@@ -37,6 +37,7 @@ public class BroadlinkSocketModel2Handler extends BroadlinkSocketHandler {
         payload[4] = (byte) status;
         byte message[] = buildMessage((byte) 106, payload);
         sendDatagram(message);
+	receiveDatagram("acknowledgment packet");
     }
 
     protected boolean getStatusFromDevice() {

--- a/addons/binding/org.openhab.binding.broadlink/src/main/java/org/openhab/binding/broadlink/handler/BroadlinkSocketModel2Handler.java
+++ b/addons/binding/org.openhab.binding.broadlink/src/main/java/org/openhab/binding/broadlink/handler/BroadlinkSocketModel2Handler.java
@@ -62,8 +62,7 @@ public class BroadlinkSocketModel2Handler extends BroadlinkSocketHandler {
                 logError("Null payload in response from model 2 status request");
                 return false;
             }
-	    	
-			updateState("powerOn", deriveOnOffStateFromPayload(payload));
+            updateState("powerOn", deriveOnOffStateFromPayload(decodedPayload));
             return true;
         } catch (Exception ex) {
                 logError("Exception while getting status from device", ex);


### PR DESCRIPTION
Broadlink SP2-3 devices consistently report state OnOffType.OFF. This is due to the state being derived from the variable used to store the status command payload instead of the decrypted payload which is received. Additionally, the SP2-3 devices sends an acknowledgment packet when commanded to change its state. Since this packet is not captured immediately after the command is sent to the device, this packet is buffered and read the next time the status of the device is read. This means the acknowledgement packet is read as a status packet, causing openhab to misinterpret the device's state until this packet is cleared from the buffer and an actual device state packet is read.

This PR fixes both of these problems. Tested and verified on Ubuntu 16.04 and OpenHAB 2.2 (running in docker)

JAR: https://www.dropbox.com/s/iuocwozkz6v8by2/org.openhab.binding.broadlink-2.4.0-SNAPSHOT.jar?dl=0

