### PR TITLE
Fixed support for Broadlink RM3 Mini v44057 firmware.

### DIFF
--- a/bundles/org.openhab.binding.broadlink/src/main/java/org/openhab/binding/broadlink/BroadlinkBindingConstants.java
+++ b/bundles/org.openhab.binding.broadlink/src/main/java/org/openhab/binding/broadlink/BroadlinkBindingConstants.java
@@ -37,6 +37,7 @@ public class BroadlinkBindingConstants {
     public static final ThingTypeUID THING_TYPE_RM = new ThingTypeUID("broadlink", "rm");
     public static final ThingTypeUID THING_TYPE_RM2 = new ThingTypeUID("broadlink", "rm2");
     public static final ThingTypeUID THING_TYPE_RM3 = new ThingTypeUID("broadlink", "rm3");
+    public static final ThingTypeUID THING_TYPE_RM3Q = new ThingTypeUID("broadlink", "rm3q");
     public static final ThingTypeUID THING_TYPE_RM4 = new ThingTypeUID("broadlink", "rm4");
     public static final ThingTypeUID THING_TYPE_A1 = new ThingTypeUID("broadlink", "a1");
     public static final ThingTypeUID THING_TYPE_MP1 = new ThingTypeUID("broadlink", "mp1");
@@ -90,6 +91,7 @@ public class BroadlinkBindingConstants {
     public static final String RM1 = "Broadlink RM1";
     public static final String RM2 = "Broadlink RM2";
     public static final String RM3 = "Broadlink RM3";
+    public static final String RM3Q = "Broadlink RM3 v11057";
     public static final String RM4 = "Broadlink RM4 / RM4 Mini / RM4 Pro";
     public static final String RMProPhicomm = "RMProPhicomm";
     public static final String RM2HomePlus = "RM2HomePlus";
@@ -166,6 +168,7 @@ public class BroadlinkBindingConstants {
         SUPPORTED_THING_TYPES_UIDS_TO_NAME_MAP.put(THING_TYPE_RM, RM);
         SUPPORTED_THING_TYPES_UIDS_TO_NAME_MAP.put(THING_TYPE_RM2, RM2);
         SUPPORTED_THING_TYPES_UIDS_TO_NAME_MAP.put(THING_TYPE_RM3, RM3);
+        SUPPORTED_THING_TYPES_UIDS_TO_NAME_MAP.put(THING_TYPE_RM3Q, RM3Q);
         SUPPORTED_THING_TYPES_UIDS_TO_NAME_MAP.put(THING_TYPE_RM4, RM4);
         SUPPORTED_THING_TYPES_UIDS_TO_NAME_MAP.put(THING_TYPE_A1, A1);
         SUPPORTED_THING_TYPES_UIDS_TO_NAME_MAP.put(THING_TYPE_MP1, MP1);

--- a/bundles/org.openhab.binding.broadlink/src/main/java/org/openhab/binding/broadlink/handler/BroadlinkRemoteModel3V44057Handler.java
+++ b/bundles/org.openhab.binding.broadlink/src/main/java/org/openhab/binding/broadlink/handler/BroadlinkRemoteModel3V44057Handler.java
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.broadlink.handler;
+
+import org.eclipse.smarthome.core.thing.Thing;
+
+/**
+ * Supports quirks in V44057 firmware.
+ * 
+ * @author Stewart Cossey - Initial contribution
+ */
+public class BroadlinkRemoteModel3V44057Handler extends BroadlinkRemoteModel4Handler {
+
+	public BroadlinkRemoteModel3V44057Handler(Thing thing) {
+        super(thing);
+    }
+    
+    protected boolean getStatusFromDevice() {
+        return true;
+    }
+
+
+}

--- a/bundles/org.openhab.binding.broadlink/src/main/java/org/openhab/binding/broadlink/internal/BroadlinkHandlerFactory.java
+++ b/bundles/org.openhab.binding.broadlink/src/main/java/org/openhab/binding/broadlink/internal/BroadlinkHandlerFactory.java
@@ -55,6 +55,10 @@ public class BroadlinkHandlerFactory extends BaseThingHandlerFactory {
             if (logger.isDebugEnabled()) logger.debug("RM 3 handler requested created");
             return new BroadlinkRemoteHandler(thing);
         }
+        if (thingTypeUID.equals(BroadlinkBindingConstants.THING_TYPE_RM3Q)) {
+            if (logger.isDebugEnabled()) logger.debug("RM 3 v11057 handler requested created");
+            return new BroadlinkRemoteModel3V44057Handler(thing);
+        }
         if (thingTypeUID.equals(BroadlinkBindingConstants.THING_TYPE_RM4)) {
             if (logger.isDebugEnabled()) logger.debug("RM 4 handler requested created");
             return new BroadlinkRemoteModel4Handler(thing);

--- a/bundles/org.openhab.binding.broadlink/src/main/java/org/openhab/binding/broadlink/internal/ModelMapper.java
+++ b/bundles/org.openhab.binding.broadlink/src/main/java/org/openhab/binding/broadlink/internal/ModelMapper.java
@@ -61,7 +61,7 @@ public class ModelMapper {
         if (model == 0x27c2)
             return BroadlinkBindingConstants.THING_TYPE_RM3; // RM Mini 3, firmware rev v40
         if (model == 0x5f36) 
-            return BroadlinkBindingConstants.THING_TYPE_RM4; // RM Mini 3, firmware v44057 - treated as an RM4 due to sendCode quirk
+            return BroadlinkBindingConstants.THING_TYPE_RM3Q; // RM Mini 3, firmware rev v44057 - has sendCode quirk from RM4
         if (model == 0x51da)
             return BroadlinkBindingConstants.THING_TYPE_RM4; // RM4b
         if (model >= 0x6020 && model <= 0x602f)

--- a/bundles/org.openhab.binding.broadlink/src/main/resources/ESH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.broadlink/src/main/resources/ESH-INF/thing/thing-types.xml
@@ -762,6 +762,85 @@
 		</parameter>
 	</config-description>
 	</thing-type>
+	<thing-type id="rm3q">
+		<label>Broadlink RM3 v44057</label>
+		<description>The Broadlink RM 3/Mini is an IR transmitter with Wi-Fi connectivity.</description>
+		<channels>
+			<channel id="command" typeId="command" />
+		</channels>
+		<config-description>
+			<parameter name="ipAddress" type="text">
+			<context>network-address</context>
+			<label>Network Address</label>
+			<description>Network address of the device.</description>
+			<required>true</required>
+			<advanced>true</advanced>
+			</parameter>
+			<parameter name="staticIp" type="boolean">
+			<context>static-ip</context>
+			<label>Static IP</label>
+			<description>Will the device always be given this network address?</description>
+			<required>true</required>
+			<advanced>true</advanced>
+			<default>true</default>
+			</parameter>
+			<parameter name="port" type="integer">
+			<context>network-port</context>
+			<label>Network Port</label>
+			<description>Network port of the device.</description>
+			<required>true</required>
+			<advanced>true</advanced>
+			</parameter>
+			<parameter name="mac" type="text">
+			<context>mac-address</context>
+			<label>MAC Address</label>
+			<description>MAC address of the device.</description>
+			<required>true</required>
+			<advanced>true</advanced>
+			</parameter>
+			<parameter name="pollingInterval" type="integer" min="30" step="1">
+			<label>Polling Interval</label>
+			<description>The interval in seconds for polling the status of the device.</description>
+			<required>true</required>
+			<default>30</default>
+			</parameter>
+				<parameter name="mapFilename" type="text">
+					<label>Map File</label>
+					<description>Enter name of file containing mapping of commands to IR codes</description>
+			<required>true</required>
+			<default>broadlink.map</default>
+				</parameter>
+					<parameter name="authorizationKey" type="text">
+					<context>password</context>
+					<label>Authentication Key</label>
+					<description>Authentication key of the device.</description>
+					<required>true</required>
+					<default>097628343fe99e23765c1513accf8b02</default>
+				</parameter>
+				<parameter name="iv" type="text">
+					<context>password</context>
+					<label>IV</label>
+					<description>Initialization Vector</description>
+					<required>true</required>
+					<default>562e17996d093d28ddb3ba695a2e6f58</default>
+				</parameter>
+			<parameter name="retries" type="integer" min="0" max="1">
+			<label>Retries</label>
+			<description>The number of times to retry a network request before declaring the device Offline</description>
+			<required>true</required>
+			<advanced>true</advanced>
+			<default>1</default>
+			</parameter>
+			<parameter name="ignoreFailedUpdates" type="boolean">
+			<context>ignore-failed-updates</context>
+			<label>Ignore Failed Updates</label>
+			<description>Should failed status requests force the device offline?</description>
+			<required>true</required>
+			<advanced>true</advanced>
+			<default>false</default>
+			</parameter>
+		</config-description>
+		</thing-type>
 	<thing-type id="rm4">
 		<label>Broadlink RM4</label>
 		<description>The Broadlink RM 4 is an IR transmitter with Wi-Fi connectivity.</description>
@@ -925,15 +1004,3 @@
 	<state readOnly="true"></state>
 	</channel-type>
 </thing:thing-descriptions>
-
-
-
-
-
-
-
-
-
-
-
-

--- a/bundles/org.openhab.binding.broadlink/src/test/java/org/openhab/binding/broadlink/internal/ModelMapperTest.java
+++ b/bundles/org.openhab.binding.broadlink/src/test/java/org/openhab/binding/broadlink/internal/ModelMapperTest.java
@@ -35,9 +35,9 @@ public class ModelMapperTest {
     }
 
     @Test
-    public void mapsRm35f36AsRm4() {
+    public void mapsRm35f36AsRm3Q() {
         assertEquals(
-            BroadlinkBindingConstants.THING_TYPE_RM4,
+            BroadlinkBindingConstants.THING_TYPE_RM3Q,
             ModelMapper.getThingType(0x5f36)
         );
     }


### PR DESCRIPTION
Two other users on the forums had mentioned that they could not use the _RM3_ mini due to the fact that _firmware 44057_ uses the _RM4_ function to send code. The problem is that the this device version is mapped to the _RM4_, but the _RM4_ code does an check in `getStatusFromDevice()` which does not apply for the _RM3_. The solution is to create a new thing type which uses a new `BroadlinkRemoteModel3V44057Handler` that inherits from the `BroadlinkRemoteModel4Handler` but sets the `getStatusFromDevice` to return true like in the base classes for the _RM3_ devices.

This has been tested as working with my RM3 mini with v44057